### PR TITLE
Change package name

### DIFF
--- a/src/main/java/kafka/xchange/TickProducer.java
+++ b/src/main/java/kafka/xchange/TickProducer.java
@@ -1,4 +1,4 @@
-package co.coinsmith.kafka.xchange;
+package kafka.xchange;
 
 import java.io.FileInputStream;
 import java.util.*;


### PR DESCRIPTION
Fixes Eclipse error `The declared package name does not match the expected package name.`