### PR TITLE
Gradle: add Eclipse plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .gradle
 /build
+
+# Eclipse artifacts
+.project
+.classpath
+.settings/
+bin/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'application'
+apply plugin: 'eclipse'
 
 mainClassName = "kafka.xchange.TickProducer"
 run {


### PR DESCRIPTION
Eclipse is useful for debugging and editing Java. Gradle support for Eclipse is top notch.